### PR TITLE
Set LDClient.send_events to false as a default

### DIFF
--- a/locust/launchdarkly_locust.py
+++ b/locust/launchdarkly_locust.py
@@ -20,6 +20,7 @@ class LaunchDarklyLocust(Locust):
     base_uri = os.environ.get('LAUNCHDARKLY_BASE_URI')
     events_uri = os.environ.get('LAUNCHDARKLY_EVENTS_URI')
     stream_uri = os.environ.get('LAUNCHDARKLY_STREAM_URI')
+    send_events = False  # https://docs.launchdarkly.com/guides/flags/testing-code#managing-test-data-in-your-production-environment
     event_processor_class = LocustEventDispatcher
     feature_requester_class = LocustServerFeatureRequester
     update_processor_class = LocustStreamingProcessor


### PR DESCRIPTION
Per our guidance in [this doc](https://docs.launchdarkly.com/guides/flags/testing-code#managing-test-data-in-your-production-environment) I propose we default to _not_ sending analytics events by default.

Since this is a load testing mechanism, there's potential for a ton of unwanted noise. In my opinion, it would make more sense to have people opt-in to that if they want it for some reason.