### PR TITLE
Fix broken link to distributed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ LOCUST_MODE=slave
 LOCUST_MASTER_HOST=<hostname of master>
 ```
 
-For more information, refer to [Locust Documentation](https://docs.locust.io/en/stable/running-locust-docker.html)
+For more information, refer to [Locust Documentation](https://docs.locust.io/en/stable/running-distributed.html)
 
 
 ## FAQ


### PR DESCRIPTION
Link was 404-ing. I found a relevant page in existing docs and replaced it with that